### PR TITLE
Fix `change_parameters` for network models

### DIFF
--- a/nnmt/models/basic.py
+++ b/nnmt/models/basic.py
@@ -11,22 +11,22 @@ from .. import ureg
 class Basic(Network):
     """
     Simple basic network that does not assume any network structure.
-    
+
     This network only reads in the parameter yaml files and calculates the most
     basic dependend parameters. It converts the weights from pA to mV,
     calculates relative thresholds and converts the analysis frequencies to
     angular frequencies.
-    
+
     See Also
     --------
     nnmt.models.Network : Parent class
-    
+
     """
-    
+
     def __init__(self, network_params=None, analysis_params=None, file=None):
-        
+
         super().__init__(network_params, analysis_params, file)
-        
+
         derived_network_params = (
             self._calculate_dependent_network_parameters())
         self.network_params.update(derived_network_params)
@@ -35,9 +35,12 @@ class Basic(Network):
         derived_analysis_params = (
             self._calculate_dependent_analysis_parameters())
         self.analysis_params.update(derived_analysis_params)
-        
+
         self._convert_param_dicts_to_base_units_and_strip_units()
-        
+
+    def _instantiate(self, new_network_params, new_analysis_params):
+        return Basic(new_network_params, new_analysis_params)
+
     def _calculate_dependent_network_parameters(self):
         """
         Calculate all network parameters derived from parameters in yaml file
@@ -63,7 +66,7 @@ class Basic(Network):
         tau_s_div_C = self.network_params['tau_s'] / self.network_params['C']
         derived_params['J'] = (tau_s_div_C
                                * self.network_params['W']).to(ureg.mV)
-        
+
         derived_params['J_ext'] = (
             tau_s_div_C * self.network_params['W_ext']).to(ureg.mV)
 

--- a/nnmt/models/microcircuit.py
+++ b/nnmt/models/microcircuit.py
@@ -12,19 +12,19 @@ from .. import ureg
 class Microcircuit(Network):
     """
     The Potjans and Diesmann microcircuit model.
-    
+
     See :cite:t:`potjans2014` for details.
-    
+
     See Also
     --------
     nnmt.models.Network : Parent class
-    
+
     """
 
     def __init__(self, network_params=None, analysis_params=None, file=None):
-        
+
         super().__init__(network_params, analysis_params, file)
-        
+
         self.network_params['label'] = 'microcircuit'
         derived_network_params = (
             self._calculate_dependent_network_parameters())
@@ -35,9 +35,12 @@ class Microcircuit(Network):
             derived_analysis_params = (
                 self._calculate_dependent_analysis_parameters())
             self.analysis_params.update(derived_analysis_params)
-        
+
         self._convert_param_dicts_to_base_units_and_strip_units()
-        
+
+    def _instantiate(self, new_network_params, new_analysis_params):
+        return Microcircuit(new_network_params, new_analysis_params)
+
     def _calculate_dependent_network_parameters(self):
         """
         Calculate all network parameters derived from parameters in yaml file
@@ -79,7 +82,7 @@ class Microcircuit(Network):
             derived_params['J'].ito(ureg.mV)
         except AttributeError:
             pass
-        
+
         # delay matrix
         D = np.ones((dim, dim)) * self.network_params['d_e']
         D[1:dim:2] = np.ones(dim) * self.network_params['d_i']
@@ -91,11 +94,11 @@ class Microcircuit(Network):
         D[1:dim:2] = np.ones(dim) * self.network_params['d_i_sd']
         D = np.transpose(D)
         derived_params['Delay_sd'] = D
-        
+
         # larger weight for L4E->L23E connections
         derived_params['W'][0][2] *= 2.0
         derived_params['J'][0][2] *= 2.0
-        
+
         derived_params['J_ext'] = (
             tau_s_div_C * np.ones(self.network_params['K_ext'].shape)
             * self.network_params['w_ext'])
@@ -121,7 +124,7 @@ class Microcircuit(Network):
         w_min = 2 * np.pi * self.analysis_params['f_min']
         w_max = 2 * np.pi * self.analysis_params['f_max']
         dw = 2 * np.pi * self.analysis_params['df']
-        
+
         try:
             w_min = w_min.magnitude
             w_max = w_max.magnitude
@@ -135,7 +138,7 @@ class Microcircuit(Network):
             return np.arange(w_min, w_max, dw)
 
         derived_params['omegas'] = calc_evaluated_omegas(w_min, w_max, dw)
-        
+
         try:
             w_min = w_min.magnitude
             w_max = w_max.magnitude

--- a/nnmt/models/network.py
+++ b/nnmt/models/network.py
@@ -15,7 +15,7 @@ from ..utils import (
 class Network():
     """
     Basic Network parent class all other models inherit from.
-    
+
     This class serves as a container for network parameters, analysis
     parameters, and results calculated using the toolbox. It has convenient
     saving and loading methods.
@@ -31,7 +31,7 @@ class Network():
     file : str, optional
         File name of h5 file from which network can be loaded. Default is
         ``None``.
-        
+
     Attributes
     ----------
     analysis_params : dict
@@ -60,8 +60,8 @@ class Network():
     result_units : dict
         This is where the units of the results are stored. They are retrieved
         when saving results.
-        
-        
+
+
     Methods
     -------
     save
@@ -77,12 +77,12 @@ class Network():
     copy
         Returns a deep copy of the network.
     """
-    
+
     def __init__(self, network_params=None, analysis_params=None, file=None):
-        
+
         self.input_units = {}
         self.result_units = {}
-        
+
         if file:
             self.load(file)
         else:
@@ -112,11 +112,11 @@ class Network():
                 self.analysis_params = analysis_params
             else:
                 raise ValueError('Invalid value for `network_params`.')
-                        
+
             # empty results
             self.results = {}
             self.results_hash_dict = {}
-        
+
     def _convert_param_dicts_to_base_units_and_strip_units(self):
         """
         Converts the parameter dicts to base units and strips the units.
@@ -129,7 +129,7 @@ class Network():
                     dict[key] = quantity.to_base_units().magnitude
                 except AttributeError:
                     pass
-            
+
     def _add_units_to_param_dicts_and_convert_to_input_units(self):
         """
         Adds units to the parameter dicts and converts them to input units.
@@ -140,16 +140,16 @@ class Network():
         self.analysis_params = (
             self._add_units_to_dict_and_convert_to_input_units(
                 self.analysis_params))
-    
+
     def _add_units_to_dict_and_convert_to_input_units(self, dict):
         """
         Adds units to a unitless dict and converts them to input units.
-        
+
         Parameters
         ----------
         dict : dict
             Dictionary to be converted.
-            
+
         Returns
         -------
         dict
@@ -163,20 +163,20 @@ class Network():
             except KeyError:
                 pass
         return dict
-    
+
     def _add_result_units(self):
         """
         Adds units stored in networks result_units dict to results dict.
         """
-        
+
         for key, unit in self.result_units.items():
             self.results[key] = ureg.Quantity(self.results[key], unit)
-        
+
     def _strip_result_units(self):
         """
         Converts units to SI and strips units from results dict.
         """
-        
+
         for key, value in self.results.items():
             if isinstance(value, ureg.Quantity):
                 self.results[key] = value.magnitude
@@ -185,11 +185,11 @@ class Network():
     def save(self, file, overwrite=False):
         """
         Save network to h5 file.
-        
+
         The networks' dictionaires (network_params, analysis_params, results,
         results_hash_dict) are stored. Quantities are converted to value-unit
         dictionaries.
-        
+
         Parameters
         ----------
         file : str
@@ -203,7 +203,7 @@ class Network():
         io.save_network(file, self, overwrite)
         self._convert_param_dicts_to_base_units_and_strip_units()
         self._strip_result_units()
-        
+
     def save_results(self, file):
         """
         Saves results and parameters to h5 file.
@@ -219,16 +219,16 @@ class Network():
                       analysis_params=self.analysis_params)
         io.save_quantity_dict_to_h5(file, output)
         self._convert_param_dicts_to_base_units_and_strip_units()
-    
+
     def load(self, file):
         """
         Load network from h5 file.
-        
+
         The networks' dictionaires (network_params, analysis_params, results,
         results_hash_dict) are loaded.
-        
+
         Note: The network's state is overwritten!
-        
+
         Parameters:
         -----------
         file: str
@@ -266,12 +266,12 @@ class Network():
         Network object
             New network with specified parameters.
         """
-        
+
         new_network_params = self.network_params.copy()
         new_network_params.update(changed_network_params)
         new_analysis_params = self.analysis_params.copy()
         new_analysis_params.update(changed_analysis_params)
-        
+
         if overwrite:
             self.network_params = new_network_params
             self.analysis_params = new_analysis_params
@@ -282,8 +282,16 @@ class Network():
             self.results_hash_dict = {}
             return self
         else:
-            return Network(new_network_params, new_analysis_params)
-        
+            return self._instantiate(new_network_params, new_analysis_params)
+
+    def _instantiate(self, new_network_params, new_analysis_params):
+        """
+        Helper method for change of parameters that instatiates network.
+
+        Needs to be implemented for each child class seperately.
+        """
+        return Network(new_network_params, new_analysis_params)
+
     def copy(self):
         """
         Returns a deep copy of the network.
@@ -300,7 +308,7 @@ class Network():
     def clear_results(self, results=None):
         """
         Remove calculated results or specified ones from internal dicts.
-        
+
         Parameters
         ----------
         results: None or list

--- a/nnmt/models/plain.py
+++ b/nnmt/models/plain.py
@@ -2,9 +2,12 @@ from .network import Network
 
 
 class Plain(Network):
-    
+
     def __init__(self, network_params=None, analysis_params=None, file=None):
-        
+
         super().__init__(network_params, analysis_params, file)
-        
+
         self._convert_param_dicts_to_base_units_and_strip_units()
+
+    def _instantiate(self, new_network_params, new_analysis_params):
+        return Plain._instantiate(new_network_params, new_analysis_params)


### PR DESCRIPTION
The different models used to not update the derived parameters
when calling `change_parameters`. Now, I have introduced a helper
function `_instantiate` that is called by `change_parameters`. It
needs to be overwritten by each child class of `nnmt.models.Network`.